### PR TITLE
Penalty Shootout

### DIFF
--- a/crates/hulk_behavior_simulator/build.rs
+++ b/crates/hulk_behavior_simulator/build.rs
@@ -28,6 +28,7 @@ fn main() -> Result<()> {
                     "control::primary_state_filter",
                     "control::motion::look_around",
                     "control::motion::motion_selector",
+                    "control::penalty_shot_direction_estimation",
                     "control::referee_position_provider",
                     "control::role_assignment",
                     "control::rule_obstacle_composer",

--- a/crates/hulk_behavior_simulator/src/autoref.rs
+++ b/crates/hulk_behavior_simulator/src/autoref.rs
@@ -127,6 +127,7 @@ pub fn auto_assistant_referee(
     for command in game_controller_commands.read() {
         match *command {
             GameControllerCommand::SetGameState(_) => {}
+            GameControllerCommand::SetGamePhase(_) => {}
             GameControllerCommand::SetSubState(Some(SubState::CornerKick), team) => {
                 let side = if let Some(ball) = ball.state.as_mut() {
                     if ball.position.x() >= 0.0 {

--- a/crates/hulk_behavior_simulator/src/bin/penalty_shootout_attacking.rs
+++ b/crates/hulk_behavior_simulator/src/bin/penalty_shootout_attacking.rs
@@ -1,0 +1,55 @@
+use bevy::prelude::*;
+
+use linear_algebra::{point, vector, Isometry2, Vector};
+use scenario::scenario;
+use spl_network_messages::{GameState, PlayerNumber, Team};
+use types::ball_position::SimulatorBallState;
+
+use hulk_behavior_simulator::{
+    ball::BallResource,
+    game_controller::{GameController, GameControllerCommand},
+    robot::Robot,
+    time::{Ticks, TicksTime},
+};
+
+#[scenario]
+fn penalty_shootout_attacking(app: &mut App) {
+    app.add_systems(Startup, startup);
+    app.add_systems(Update, update);
+}
+
+fn startup(
+    mut commands: Commands,
+    mut game_controller_commands: EventWriter<GameControllerCommand>,
+    mut ball: ResMut<BallResource>,
+) {
+    let mut robot = Robot::new(PlayerNumber::One);
+    *robot.ground_to_field_mut() = Isometry2::from_parts(vector![2.8, 0.0], 0.0);
+    commands.spawn(robot);
+    ball.state = Some(SimulatorBallState {
+        position: point!(3.2, 0.0),
+        velocity: Vector::zeros(),
+    });
+    game_controller_commands.send(GameControllerCommand::SetGamePhase(
+        spl_network_messages::GamePhase::PenaltyShootout {
+            kicking_team: Team::Hulks,
+        },
+    ));
+    game_controller_commands.send(GameControllerCommand::SetGameState(GameState::Set));
+}
+
+#[allow(clippy::too_many_arguments)]
+fn update(
+    game_controller: ResMut<GameController>,
+    time: ResMut<Time<Ticks>>,
+    mut exit: EventWriter<AppExit>,
+) {
+    if game_controller.state.hulks_team.score > 0 {
+        println!("Done");
+        exit.send(AppExit::Success);
+    }
+    if time.ticks() >= 10_000 {
+        println!("No goal was scored :(");
+        exit.send(AppExit::from_code(1));
+    }
+}

--- a/crates/hulk_behavior_simulator/src/bin/penalty_shootout_defending.rs
+++ b/crates/hulk_behavior_simulator/src/bin/penalty_shootout_defending.rs
@@ -48,12 +48,12 @@ fn update(
     mut exit: EventWriter<AppExit>,
     mut robots: Query<&mut Robot>,
 ) {
-    if time.ticks() == 2200 {
+    if time.ticks() == 2 {
         if let Some(ball) = ball.state.as_mut() {
             ball.velocity = vector![-2.5, -0.4];
         }
     }
-    if time.ticks() > 2200 {
+    if time.ticks() > 2 {
         if let Some(ball) = ball.state.as_mut() {
             if ball.velocity.norm() < 0.01 {
                 println!("Prevented opponent from scoring!");

--- a/crates/hulk_behavior_simulator/src/bin/penalty_shootout_defending.rs
+++ b/crates/hulk_behavior_simulator/src/bin/penalty_shootout_defending.rs
@@ -1,0 +1,96 @@
+use bevy::prelude::*;
+
+use linear_algebra::{point, vector, Isometry2, Vector};
+use scenario::scenario;
+use spl_network_messages::{GameState, PlayerNumber, Team};
+use types::{
+    ball_position::SimulatorBallState,
+    motion_command::{JumpDirection, MotionCommand},
+};
+
+use hulk_behavior_simulator::{
+    ball::BallResource,
+    game_controller::{GameController, GameControllerCommand},
+    robot::Robot,
+    time::{Ticks, TicksTime},
+};
+
+#[scenario]
+fn penalty_shootout_defending(app: &mut App) {
+    app.add_systems(Startup, startup);
+    app.add_systems(Update, update);
+}
+fn startup(
+    mut commands: Commands,
+    mut game_controller_commands: EventWriter<GameControllerCommand>,
+    mut ball: ResMut<BallResource>,
+) {
+    let mut robot = Robot::new(PlayerNumber::One);
+    *robot.ground_to_field_mut() = Isometry2::from_parts(vector![-4.5, 0.0], 0.0);
+    commands.spawn(robot);
+    ball.state = Some(SimulatorBallState {
+        position: point!(-3.2, 0.0),
+        velocity: Vector::zeros(),
+    });
+    game_controller_commands.send(GameControllerCommand::SetGamePhase(
+        spl_network_messages::GamePhase::PenaltyShootout {
+            kicking_team: Team::Opponent,
+        },
+    ));
+    game_controller_commands.send(GameControllerCommand::SetGameState(GameState::Set));
+}
+
+#[allow(clippy::too_many_arguments)]
+fn update(
+    game_controller: ResMut<GameController>,
+    time: ResMut<Time<Ticks>>,
+    mut ball: ResMut<BallResource>,
+    mut exit: EventWriter<AppExit>,
+    mut robots: Query<&mut Robot>,
+) {
+    if time.ticks() == 2200 {
+        if let Some(ball) = ball.state.as_mut() {
+            ball.velocity = vector![-2.5, -0.4];
+        }
+    }
+    if time.ticks() > 2200 {
+        if let Some(ball) = ball.state.as_mut() {
+            if ball.velocity.norm() < 0.01 {
+                println!("Prevented opponent from scoring!");
+                exit.send(AppExit::Success);
+            }
+            let robot = robots.single_mut();
+
+            // basic collision physics
+            let field_to_ground = robot.ground_to_field().inverse();
+            let ball_in_ground = field_to_ground * ball.position;
+            let velocity_in_ground = field_to_ground * ball.velocity;
+
+            if let MotionCommand::Jump {
+                direction: JumpDirection::Center,
+            } = robot.database.main_outputs.motion_command
+            {
+                let x = ball_in_ground.x();
+                let y = ball_in_ground.y();
+                let ball_is_within_wide_stance = (x * x) / (0.04) + (y * y) / (0.16) < 1.0;
+                if ball_is_within_wide_stance
+                    && ball_in_ground
+                        .coords()
+                        .normalize()
+                        .dot(velocity_in_ground.normalize())
+                        < -0.3
+                {
+                    ball.velocity = vector!(0.2, 0.0);
+                }
+            };
+        }
+    }
+    if game_controller.state.opponent_team.score > 0 {
+        println!("Failed to prevent opponents from scoring");
+        exit.send(AppExit::from_code(1));
+    }
+    if time.ticks() >= 10_000 {
+        println!("Done");
+        exit.send(AppExit::Success);
+    }
+}

--- a/crates/hulk_behavior_simulator/src/fake_data.rs
+++ b/crates/hulk_behavior_simulator/src/fake_data.rs
@@ -19,7 +19,6 @@ use types::{
     joints::head::HeadJoints,
     obstacles::Obstacle,
     parameters::{BallFilterParameters, CameraMatrixParameters},
-    penalty_shot_direction::PenaltyShotDirection,
     sensor_data::SensorData,
 };
 
@@ -65,7 +64,6 @@ pub struct MainOutputs {
     pub hypothetical_ball_positions: MainOutput<Vec<HypotheticalBallPosition<Ground>>>,
     pub is_localization_converged: MainOutput<bool>,
     pub obstacles: MainOutput<Vec<Obstacle>>,
-    pub penalty_shot_direction: MainOutput<Option<PenaltyShotDirection>>,
     pub sensor_data: MainOutput<SensorData>,
     pub stand_up_back_estimated_remaining_duration: MainOutput<Option<Duration>>,
     pub calibration_command: MainOutput<Option<CalibrationCommand>>,
@@ -100,7 +98,6 @@ impl FakeData {
             hypothetical_ball_positions: last_database.hypothetical_ball_positions.clone().into(),
             is_localization_converged: last_database.is_localization_converged.into(),
             obstacles: last_database.obstacles.clone().into(),
-            penalty_shot_direction: last_database.penalty_shot_direction.into(),
             ground_to_field: last_database.ground_to_field.into(),
             sensor_data: last_database.sensor_data.clone().into(),
             stand_up_front_estimated_remaining_duration: last_database

--- a/crates/hulk_behavior_simulator/src/game_controller.rs
+++ b/crates/hulk_behavior_simulator/src/game_controller.rs
@@ -17,6 +17,7 @@ struct GameControllerControllerState {
 #[derive(Clone, Copy, Event)]
 pub enum GameControllerCommand {
     SetGameState(GameState),
+    SetGamePhase(GamePhase),
     SetSubState(Option<SubState>, Team),
     SetKickingTeam(Team),
     Goal(Team),
@@ -36,6 +37,10 @@ fn game_controller_controller(
         match *command {
             GameControllerCommand::SetGameState(game_state) => {
                 game_controller.state.game_state = game_state;
+                state.last_state_change = time.as_generic();
+            }
+            GameControllerCommand::SetGamePhase(game_phase) => {
+                game_controller.state.game_phase = game_phase;
                 state.last_state_change = time.as_generic();
             }
             GameControllerCommand::SetKickingTeam(team) => {


### PR DESCRIPTION
## Introduced Changes

Allows setting of GamePhase
Adds penalty shot direction estimation to `build.rs`
Adds penalty shootout scenarios

Fixes #

## ToDo / Known Issues

This scenario performs similar collision calculation as `intercept_ball` with the addition that it checks the motion command for the robot.
Currently this only checks for center jump (wide stance) and thus expands the collision radius into an ellipse.
Would it make sense to expand this scenario to include multiple types of opponents kicks for the left and right jumps as well? Can this even be visualized in any sensible way?

## Ideas for Next Iterations (Not This PR)

## How to Test
